### PR TITLE
Refactor RelayStatus enum with conversions and add demo example

### DIFF
--- a/examples/relay_status_demo.rs
+++ b/examples/relay_status_demo.rs
@@ -1,0 +1,34 @@
+use qwiic_relay_rs::RelayStatus;
+
+fn main() {
+    println!("RelayStatus Demo");
+    println!("================");
+    
+    // Demonstrate enum values
+    println!("RelayStatus::Off = {}", RelayStatus::Off as u8);
+    println!("RelayStatus::On = {}", RelayStatus::On as u8);
+    
+    // Demonstrate bool conversions
+    let off_status = RelayStatus::from(false);
+    let on_status = RelayStatus::from(true);
+    println!("\nBool to RelayStatus:");
+    println!("false -> {:?}", off_status);
+    println!("true -> {:?}", on_status);
+    
+    // Demonstrate RelayStatus to bool
+    println!("\nRelayStatus to bool:");
+    println!("RelayStatus::Off -> {}", bool::from(RelayStatus::Off));
+    println!("RelayStatus::On -> {}", bool::from(RelayStatus::On));
+    
+    // Demonstrate u8 conversions
+    println!("\nu8 to RelayStatus:");
+    println!("0 -> {:?}", RelayStatus::from(0u8));
+    println!("1 -> {:?}", RelayStatus::from(1u8));
+    println!("255 -> {:?}", RelayStatus::from(255u8));
+    
+    // Demonstrate equality
+    println!("\nEquality checks:");
+    println!("RelayStatus::Off == RelayStatus::Off: {}", RelayStatus::Off == RelayStatus::Off);
+    println!("RelayStatus::On == RelayStatus::On: {}", RelayStatus::On == RelayStatus::On);
+    println!("RelayStatus::Off == RelayStatus::On: {}", RelayStatus::Off == RelayStatus::On);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,34 @@ pub enum RelayState {
 }
 
 /// Status values returned by the relay board.
-#[derive(Copy, Clone)]
-pub enum Status {
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RelayStatus {
     Off = 0,
+    On = 1,
+}
+
+impl From<bool> for RelayStatus {
+    fn from(value: bool) -> Self {
+        if value { RelayStatus::On } else { RelayStatus::Off }
+    }
+}
+
+impl From<RelayStatus> for bool {
+    fn from(status: RelayStatus) -> Self {
+        status == RelayStatus::On
+    }
+}
+
+impl From<u8> for RelayStatus {
+    fn from(value: u8) -> Self {
+        if value != 0 { RelayStatus::On } else { RelayStatus::Off }
+    }
+}
+
+impl From<RelayStatus> for u8 {
+    fn from(status: RelayStatus) -> Self {
+        status as u8
+    }
 }
 
 /// Configuration for a Qwiic Relay board.
@@ -155,7 +180,7 @@ impl QwiicRelay {
                 let read_command = 0x04 + num;
                 let temp = self.dev.smbus_read_byte_data(read_command)?;
 
-                if temp == (Status::Off as u8) {
+                if RelayStatus::from(temp) == RelayStatus::Off {
                     self.write_byte((Command::DualQuadToggleBase as u8) + num)?;
                 }
                 Ok(())
@@ -177,7 +202,7 @@ impl QwiicRelay {
                 let read_command = 0x04 + num;
                 let temp = self.dev.smbus_read_byte_data(read_command)?;
 
-                if temp != (Status::Off as u8) {
+                if RelayStatus::from(temp) == RelayStatus::On {
                     self.write_byte((Command::DualQuadToggleBase as u8) + num)?;
                 }
                 Ok(())
@@ -194,28 +219,13 @@ impl QwiicRelay {
     /// # Returns
     /// A Result containing true if the relay is on, false if off, or an I2C error.
     pub fn get_relay_state(&mut self, relay_num: Option<u8>) -> RelayDeviceStatus {
-        match relay_num {
-            Some(num) => {
-                let read_command = 0x04 + num;
-                let temp = self.dev.smbus_read_byte_data(read_command)?;
-
-                if temp != (Status::Off as u8) {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-            None => {
-                let read_command = 0x04;
-                let temp = self.dev.smbus_read_byte_data(read_command)?;
-
-                if temp != (Status::Off as u8) {
-                    Ok(true)
-                } else {
-                    Ok(false)
-                }
-            }
-        }
+        let read_command = match relay_num {
+            Some(num) => 0x04 + num,
+            None => 0x04,
+        };
+        
+        let temp = self.dev.smbus_read_byte_data(read_command)?;
+        Ok(RelayStatus::from(temp).into())
     }
 
     /// Turns on all relays on the board.
@@ -404,8 +414,42 @@ mod tests {
     }
 
     #[test]
-    fn test_status_enum_values() {
-        assert_eq!(Status::Off as u8, 0);
+    fn test_relay_status_enum_values() {
+        assert_eq!(RelayStatus::Off as u8, 0);
+        assert_eq!(RelayStatus::On as u8, 1);
+    }
+
+    #[test]
+    fn test_relay_status_from_bool() {
+        assert_eq!(RelayStatus::from(false), RelayStatus::Off);
+        assert_eq!(RelayStatus::from(true), RelayStatus::On);
+    }
+
+    #[test]
+    fn test_relay_status_to_bool() {
+        assert_eq!(bool::from(RelayStatus::Off), false);
+        assert_eq!(bool::from(RelayStatus::On), true);
+    }
+
+    #[test]
+    fn test_relay_status_from_u8() {
+        assert_eq!(RelayStatus::from(0u8), RelayStatus::Off);
+        assert_eq!(RelayStatus::from(1u8), RelayStatus::On);
+        assert_eq!(RelayStatus::from(255u8), RelayStatus::On);
+        assert_eq!(RelayStatus::from(10u8), RelayStatus::On);
+    }
+
+    #[test]
+    fn test_relay_status_to_u8() {
+        assert_eq!(u8::from(RelayStatus::Off), 0);
+        assert_eq!(u8::from(RelayStatus::On), 1);
+    }
+
+    #[test]
+    fn test_relay_status_equality() {
+        assert_eq!(RelayStatus::Off, RelayStatus::Off);
+        assert_eq!(RelayStatus::On, RelayStatus::On);
+        assert_ne!(RelayStatus::Off, RelayStatus::On);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Refactored the relay status enum from `Status` to `RelayStatus` with explicit `On` and `Off` variants
- Added implementations for conversions between `RelayStatus`, `bool`, and `u8` for easier and safer usage
- Updated all internal usages of relay status to use the new `RelayStatus` enum
- Added a new example `relay_status_demo.rs` demonstrating enum values, conversions, and equality checks
- Added comprehensive unit tests for the new `RelayStatus` enum and its conversions

## Changes

### Core Library
- Renamed `Status` enum to `RelayStatus` and derived `Debug` and `PartialEq` for better usability
- Implemented `From<bool>`, `From<RelayStatus> for bool`, `From<u8>`, and `From<RelayStatus> for u8` traits for seamless conversions
- Refactored `get_relay_state` and other internal methods to use `RelayStatus` instead of raw `u8` or old enum

### Examples
- Added `examples/relay_status_demo.rs` showcasing:
  - Enum variant values
  - Conversions between `bool`, `u8`, and `RelayStatus`
  - Equality checks between enum variants

### Tests
- Added tests covering:
  - Enum values correctness
  - Conversion from and to `bool` and `u8`
  - Equality comparisons

## Test plan
- Run existing and new unit tests to verify correctness
- Build and run the new example to ensure it outputs expected results

This refactor improves code clarity, type safety, and usability of the relay status representation in the library.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ff6e8e9a-a6a9-498b-8626-b68e8a4855f4